### PR TITLE
UX: Fix spacing in composer

### DIFF
--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -123,7 +123,6 @@
   }
   .title-and-category {
     box-sizing: border-box;
-    padding: 0 0 0 1em;
   }
 
   &:not(.show-preview) {
@@ -137,6 +136,7 @@
   }
   .submit-panel {
     padding: 0 1em;
+    margin-bottom: 8px;
   }
 }
 


### PR DESCRIPTION
1. Removes unnecessary left margin on composer-fields
2. Adds margin to the bottom of composer

Before / After

<img width="367" alt="Screen Shot 2021-12-04 at 17 25 56" src="https://user-images.githubusercontent.com/66961/144716908-5b3341a6-5e5a-4568-88bd-72bd49f4e48c.png"> <img width="367" alt="Screen Shot 2021-12-04 at 17 25 41" src="https://user-images.githubusercontent.com/66961/144716912-59050b07-28a2-4c46-af7c-2a258c7616c8.png">


